### PR TITLE
add timeout to http client

### DIFF
--- a/influxdb.go
+++ b/influxdb.go
@@ -58,6 +58,7 @@ func (r *reporter) makeClient() (err error) {
 		URL:      r.url,
 		Username: r.username,
 		Password: r.password,
+		Timeout:  time.Second * 5,
 	})
 
 	return


### PR DESCRIPTION
this adds a timeout to the http client.

for some reason clients using this lib sometimes stop sending metrics.

we assume this is due to the missing timeout and a endless hanging http-request.